### PR TITLE
add tracking-ids to spaced group

### DIFF
--- a/packages/components/src/SpacedGroup/SpacedGroup.js
+++ b/packages/components/src/SpacedGroup/SpacedGroup.js
@@ -67,15 +67,12 @@ const buildStyles = ({
   };
 };
 
-const passThroughProps = ['data-component', 'data-test'];
-
-const SpacedGroupDiv = createComponent(buildStyles, 'div', passThroughProps);
-
-const SpacedGroupLabel = createComponent(buildStyles, 'div', passThroughProps);
-
 const SpacedGroup = props => {
-  const SpacedGroupImpl =
-    props.is === 'div' ? SpacedGroupDiv : SpacedGroupLabel;
+  const SpacedGroupImpl = createComponent(
+    buildStyles,
+    props.is,
+    ['data-component', 'data-test', 'data-tracking-id']
+  );
 
   return (
     <WithBreakpoint>


### PR DESCRIPTION
Given a SpacedGroup is supplied the `is` prop the value `label` we should be able to apply a `data-tracking-id` to ensure it can be tracked in pendo reliably. Given labels can wrap form controls if it would be ideal to track those interactions. 