### PR TITLE
Leave as ESM in babel output.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   babelrcRoots: ['.', 'packages/*', 'build/*'],
-  presets: ['@babel/preset-env', '@babel/preset-react'],
+  presets: [ ['@babel/preset-env', {modules: false} ], '@babel/preset-react'],
   plugins: [
     '@babel/plugin-proposal-object-rest-spread',
     'babel-plugin-transform-react-fela-display-name',

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -65,5 +65,6 @@
     "tiny-invariant": "^1.0.3",
     "underscore": "^1.9.1",
     "uuid": "^3.3.2"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/components/src/FieldSet/FieldSet.js
+++ b/packages/components/src/FieldSet/FieldSet.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { createComponent } from '../StyleProvider';
-import { WithBreakpoint } from '../WithBreakpoint';
+import { WithBreakpoint, isBreakpointDown, isBreakpointUp } from '../WithBreakpoint';
 
 const FieldSetContainer = createComponent(
   () => ({
@@ -15,11 +15,11 @@ const FieldSetContainer = createComponent(
 const FieldSetBar = createComponent(
   ({ xs, sm, md, lg, xl, breakpoint, theme }) => {
     const margin =
-      (WithBreakpoint.isBreakpointUp('xl', breakpoint) && xl) ||
-      (WithBreakpoint.isBreakpointUp('lg', breakpoint) && lg) ||
-      (WithBreakpoint.isBreakpointUp('md', breakpoint) && md) ||
-      (WithBreakpoint.isBreakpointUp('sm', breakpoint) && sm) ||
-      (WithBreakpoint.isBreakpointUp('xs', breakpoint) && xs);
+      (isBreakpointUp('xl', breakpoint) && xl) ||
+      (isBreakpointUp('lg', breakpoint) && lg) ||
+      (isBreakpointUp('md', breakpoint) && md) ||
+      (isBreakpointUp('sm', breakpoint) && sm) ||
+      (isBreakpointUp('xs', breakpoint) && xs);
 
     const width = margin + theme.FieldSet.size;
 

--- a/packages/components/src/SpacedGroup/SpacedGroup.js
+++ b/packages/components/src/SpacedGroup/SpacedGroup.js
@@ -1,16 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { createComponent, styleUtils } from '../StyleProvider';
-import { WithBreakpoint } from '../WithBreakpoint';
+import { WithBreakpoint, isBreakpointUp } from '../WithBreakpoint';
 
 const HORIZONTAL = 'horizontal';
 const VERTICAL = 'vertical';
 
 const getMargin = ({ breakpoint, xs, sm, md, lg, xl }) => {
-  if (WithBreakpoint.isBreakpointUp('xl', breakpoint) && xl) return xl;
-  if (WithBreakpoint.isBreakpointUp('lg', breakpoint) && lg) return lg;
-  if (WithBreakpoint.isBreakpointUp('md', breakpoint) && md) return md;
-  if (WithBreakpoint.isBreakpointUp('sm', breakpoint) && sm) return sm;
+  if (isBreakpointUp('xl', breakpoint) && xl) return xl;
+  if (isBreakpointUp('lg', breakpoint) && lg) return lg;
+  if (isBreakpointUp('md', breakpoint) && md) return md;
+  if (isBreakpointUp('sm', breakpoint) && sm) return sm;
   return xs;
 };
 

--- a/packages/components/src/WithBreakpoint/README.mdx
+++ b/packages/components/src/WithBreakpoint/README.mdx
@@ -8,7 +8,7 @@ import {
   PropsTable,
   ThemeDefinitionTable,
 } from '@versionone/doc-components';
-import { WithBreakpoint } from './';
+import { WithBreakpoint, isBreakpointUp, isBreakpointDown } from './';
 
 ## Usage
 
@@ -40,13 +40,13 @@ Functions that aid in determining if a provided breakpoint is equal to or above/
         <p>
           Current breakpoint above md:{' '}
           <strong>
-            {WithBreakpoint.isBreakpointUp('md', breakpoint).toString()}
+            {isBreakpointUp('md', breakpoint).toString()}
           </strong>
         </p>
         <p>
           Current breakpoint below md:{' '}
           <strong>
-            {WithBreakpoint.isBreakpointDown('md', breakpoint).toString()}
+            {isBreakpointDown('md', breakpoint).toString()}
           </strong>
         </p>
       </div>

--- a/packages/components/src/WithBreakpoint/index.js
+++ b/packages/components/src/WithBreakpoint/index.js
@@ -6,9 +6,4 @@ import {
   isBreakpointUp,
 } from './breakpointUtils';
 
-WithBreakpoint.getBreakpointValue = getBreakpointValue;
-WithBreakpoint.isBreakpointDown = isBreakpointDown;
-WithBreakpoint.isBreakpointUp = isBreakpointUp;
-WithBreakpoint.breakpointKeys = breakpointKeys;
-
-export { WithBreakpoint };
+export { WithBreakpoint, isBreakpointDown, isBreakpointUp, breakpointKeys }


### PR DESCRIPTION
Mark components package as without sideEffects.
Change WithBreakpoints\index.js to not create sideEffects (i.e. it modifies
the export of another module and
re-exports).