### PR TITLE
101 radio backgrounds

### DIFF
--- a/packages/components/src/Checkbox/Checkbox.js
+++ b/packages/components/src/Checkbox/Checkbox.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component, Fragment } from 'react';
 import { noop } from 'underscore';
 import { CheckIcon } from '@versionone/icons';
 import { createComponent, WithTheme } from '../StyleProvider';
 
-const CheckboxImpl = createComponent(
-  ({ size, theme }) => ({
+const InvisibleInput = createComponent(
+  () => ({
     position: 'absolute',
     opacity: 0,
   }),
@@ -23,7 +23,22 @@ const CheckboxImpl = createComponent(
   ],
 );
 
-class Checkbox extends React.Component {
+const CheckboxImpl = createComponent(({ size, disabled, color }) => {
+  return {
+    width: size,
+    height: size,
+    borderRadius: '3px',
+    border: '2px solid transparent',
+    borderColor: color,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'relative',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+  };
+}, 'span');
+
+class Checkbox extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
@@ -33,14 +48,22 @@ class Checkbox extends React.Component {
   }
 
   toggleCheck(ev) {
+    const { onClick } = this.props;
     this.setState(prevState => ({
       checked: !prevState.checked,
     }));
-    this.props.onClick(ev);
+    onClick(ev);
   }
 
   render() {
-    const { size, id, onClick, disabled, ...rest } = this.props;
+    const {
+      size,
+      id,
+      onClick,
+      disabled,
+      'data-trackingid': trackingId,
+      ...rest
+    } = this.props;
     const { checked } = this.state;
 
     return (
@@ -49,30 +72,17 @@ class Checkbox extends React.Component {
           const color = theme.Checkbox.main;
 
           return (
-            <React.Fragment>
-              <CheckboxImpl
+            <Fragment>
+              <InvisibleInput
                 {...rest}
                 onChange={this.toggleCheck}
                 type="checkbox"
                 size={size}
                 checked={checked}
                 id={id}
-                data-trackingid={this.props['data-trackingid']}
+                data-trackingid={trackingId}
               />
-              <span
-                style={{
-                  width: size,
-                  height: size,
-                  borderRadius: '3px',
-                  border: '2px solid transparent',
-                  borderColor: color,
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  position: 'relative',
-                  cursor: disabled ? 'not-allowed' : 'pointer'
-                }}
-              >
+              <CheckboxImpl color={color} disabled={disabled} size={size}>
                 {React.cloneElement(<CheckIcon />, {
                   size,
                   color: checked ? color : 'transparent',
@@ -80,8 +90,8 @@ class Checkbox extends React.Component {
                   position: 'absolute',
                   top: 4,
                 })}
-              </span>
-            </React.Fragment>
+              </CheckboxImpl>
+            </Fragment>
           );
         }}
       </WithTheme>

--- a/packages/components/src/Radio/README.mdx
+++ b/packages/components/src/Radio/README.mdx
@@ -15,9 +15,9 @@ Allows users to select one option from a set. Use RadioGroup to Wrap a set of Ra
 <Playground>
   <RadioGroup name="Name" selectedValue="red" defaultFocusedRadio={0}>
     <FormControlLabel label="Orange" control={<Radio value="orange" />} />
-    <FormControlLabel label="Green" control={<Radio value="green"/>} />
-    <FormControlLabel label="Red" control={<Radio value="red"/>} />
-    <FormControlLabel label="Blue" control={<Radio value="blue"/>} />
+    <FormControlLabel label="Green" control={<Radio value="green" />} />
+    <FormControlLabel label="Red" control={<Radio value="red" />} />
+    <FormControlLabel label="Blue" control={<Radio value="blue" />} />
   </RadioGroup>
 </Playground>
 
@@ -25,5 +25,3 @@ Allows users to select one option from a set. Use RadioGroup to Wrap a set of Ra
 
 <PropsTable of={RadioGroup} />
 <PropsTable of={Radio} />
-
-

--- a/packages/components/src/Radio/Radio.js
+++ b/packages/components/src/Radio/Radio.js
@@ -1,48 +1,21 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { noop } from 'underscore';
-import { createComponent, WithTheme } from '../StyleProvider';
+import { createComponent } from '../StyleProvider';
 
-const RadioImpl = createComponent(
-  ({ disabled, checked, size, theme }) => ({
-    height: size,
-    width: size,
+const InvisibleInput = createComponent(
+  () => ({
+    height: 0,
+    width: 0,
     alignItems: 'center',
     position: 'relative',
     outline: 'none',
     margin: '4px',
     textTransform: 'none',
-    ':before': {
-      content:'""',
-      color: theme.Button.standard.text,
-      height: size,
-      width: size,
-      minWidth: size,
-      minHeight: size,
-      borderRadius: '50%',
-      border: '3px solid transparent',
-      borderColor: checked ? theme.Radio.selected : theme.Radio.main,
-      backgroundColor: theme.Radio.background,
-      position: 'absolute',
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)',
-    },
-    ':after': {
-      content:'""',
-      width: size/2,
-      height: size/2,
-      borderRadius: '50%',
-      backgroundColor: checked ? theme.Radio.selected : 'transparent', 
-      position: 'absolute',
-      display: 'block',
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)',
-    },
   }),
   'input',
   [
+    'checked',
     'disabled',
     'onClick',
     'onChange',
@@ -53,6 +26,41 @@ const RadioImpl = createComponent(
     'value',
     'data-component',
   ],
+);
+
+const Circle = createComponent(
+  ({ checked, disabled, size, theme }) => {
+    const innerCircle = {
+      ':before': {
+        content: '""',
+        width: size / 2,
+        height: size / 2,
+        borderRadius: '50%',
+        backgroundColor: checked ? theme.Radio.selected : 'transparent',
+        position: 'absolute',
+        display: 'block',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+      },
+    };
+    return {
+      position: 'relative',
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      color: theme.Button.standard.text,
+      height: size,
+      width: size,
+      minWidth: size,
+      minHeight: size,
+      borderRadius: '50%',
+      border: '1px solid transparent',
+      borderColor: checked ? theme.Radio.selected : theme.Radio.main,
+      backgroundColor: 'transparent',
+      ...innerCircle,
+    };
+  },
+  'span',
+  ['onClick'],
 );
 
 class Radio extends Component {
@@ -82,7 +90,8 @@ class Radio extends Component {
     const isSelected = selectedValue === value;
 
     return (
-        <RadioImpl
+      <Fragment>
+        <InvisibleInput
           {...rest}
           data-component="Radio"
           disabled={disabled}
@@ -90,7 +99,6 @@ class Radio extends Component {
           aria-selected={isSelected}
           size={size}
           tabIndex={isSelected ? '0' : '-1'}
-          onClick={onClick(index, value)}
           onFocus={onFocus}
           onBlur={onBlur}
           onChange={onChange}
@@ -98,7 +106,14 @@ class Radio extends Component {
           type="radio"
           name={name}
           value={value}
-        / >
+        />
+        <Circle
+          disabled={disabled}
+          checked={isSelected}
+          onClick={onClick(index, value)}
+          size={size}
+        />
+      </Fragment>
     );
   }
 }
@@ -120,7 +135,7 @@ Radio.propTypes = {
    * Sets the tabindex of the button; used for tab order.
    */
   tabIndex: PropTypes.string,
-      /**
+  /**
    * Value of the radio
    *  */
   value: PropTypes.string.isRequired,

--- a/packages/components/src/SpacedGroup/SpacedGroup.js
+++ b/packages/components/src/SpacedGroup/SpacedGroup.js
@@ -67,15 +67,17 @@ const buildStyles = ({
   };
 };
 
-const passThroughProps = ['data-component', 'data-test', 'htmlFor'];
-
-const SpacedGroupDiv = createComponent(buildStyles, 'div', passThroughProps);
-
-const SpacedGroupLabel = createComponent(buildStyles, 'label', passThroughProps);
+const passThroughProps = [
+  'data-component',
+  'data-test',
+  'data-trackingid',
+  'htmlFor',
+];
 
 const SpacedGroup = props => {
-  const SpacedGroupImpl =
-    props.is === 'div' ? SpacedGroupDiv : SpacedGroupLabel;
+  const { is } = props;
+
+  const SpacedGroupImpl = createComponent(buildStyles, is, passThroughProps);
 
   return (
     <WithBreakpoint>
@@ -94,8 +96,11 @@ const SpacedGroup = props => {
           breakpoint={breakpoint}
           data-component="SpacedGroup"
           data-test={props['data-test']}
+          data-trackingid={props['data-trackingid']}
           htmlFor={props.htmlFor}
-        >{props.children}</SpacedGroupImpl>
+        >
+          {props.children}
+        </SpacedGroupImpl>
       )}
     </WithBreakpoint>
   );
@@ -148,7 +153,7 @@ SpacedGroup.propTypes = {
    * The underlying DOM element
    */
   is: PropTypes.oneOf(['div', 'label']),
-    /**
+  /**
    * For element
    */
   htmlFor: PropTypes.string,


### PR DESCRIPTION
Three things happened here:

1. SpacedGroup can correctly apply a `data-trackingid` to handle the case where it `is` a html label element. 

2. Radio components have a transparent background to ensure they can be used on a variety of background colors. Currently, they are fixed based on a theme, however, in a given theme it may appear on different "layers" or background colors.

3. Checkbox uses `createComponent` and avoids inline styles to ensure the style isolation mechanism is leveraged.

---

Before 2

![image](https://user-images.githubusercontent.com/1386741/66597728-924d1a80-eb6d-11e9-8f12-a270f89eac8a.png)

After 2

![image](https://user-images.githubusercontent.com/1386741/66597800-ad1f8f00-eb6d-11e9-9873-a2110357d871.png)

