### PR TITLE
Fix missing change handler and ensure the border or radios is never t…

### DIFF
--- a/packages/components/src/Radio/README.mdx
+++ b/packages/components/src/Radio/README.mdx
@@ -13,7 +13,14 @@ Allows users to select one option from a set. Use RadioGroup to Wrap a set of Ra
 ## Basic
 
 <Playground>
-  <RadioGroup name="Name" selectedValue="red" defaultFocusedRadio={0}>
+  <RadioGroup
+    name="Name"
+    selectedValue="red"
+    defaultFocusedRadio={0}
+    onChange={() => {
+      console.log('toggled');
+    }}
+  >
     <FormControlLabel label="Orange" control={<Radio value="orange" />} />
     <FormControlLabel label="Green" control={<Radio value="green" />} />
     <FormControlLabel label="Red" control={<Radio value="red" />} />

--- a/packages/components/src/Radio/Radio.js
+++ b/packages/components/src/Radio/Radio.js
@@ -53,7 +53,7 @@ const Circle = createComponent(
       minWidth: size,
       minHeight: size,
       borderRadius: '50%',
-      border: '1px solid transparent',
+      border: '1px solid',
       borderColor: checked ? theme.Radio.selected : theme.Radio.main,
       backgroundColor: 'transparent',
       ...innerCircle,
@@ -102,17 +102,13 @@ class Radio extends Component {
           onFocus={onFocus}
           onBlur={onBlur}
           onChange={onChange}
+          onClick={onClick(index, value)}
           focused={focused}
           type="radio"
           name={name}
           value={value}
         />
-        <Circle
-          disabled={disabled}
-          checked={isSelected}
-          onClick={onClick(index, value)}
-          size={size}
-        />
+        <Circle disabled={disabled} checked={isSelected} size={size} />
       </Fragment>
     );
   }

--- a/packages/components/src/SpacedGroup/SpacedGroup.js
+++ b/packages/components/src/SpacedGroup/SpacedGroup.js
@@ -74,10 +74,18 @@ const passThroughProps = [
   'htmlFor',
 ];
 
+const SpacedGroupDiv = createComponent(buildStyles, 'div', passThroughProps);
+
+const SpacedGroupLabel = createComponent(
+  buildStyles,
+  'label',
+  passThroughProps,
+);
+
 const SpacedGroup = props => {
   const { is } = props;
 
-  const SpacedGroupImpl = createComponent(buildStyles, is, passThroughProps);
+  const SpacedGroupImpl = is === 'div' ? SpacedGroupDiv : SpacedGroupLabel;
 
   return (
     <WithBreakpoint>


### PR DESCRIPTION
…ransparent


Last week's work broke the change handler on radio groups. This pr will ensure the changed handler is triggered.

In some cases, the specificity of the transparent border has greater than the colored style rule. The border-color should never be transparent.