### PR TITLE
introduce better "linking" instructions

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -33,8 +33,10 @@ Clone the repo and `cd` into the repo's directory.
 - [Document Components](getting-started/document-components)
 
 
-## Working locally with a consuming application
+## Linking 
 In some cases we need to enhance the component library and receive quick feedback of the changes in a consuming applicaiton like VersionOne or Continuum.
+
+### Working locally with a VersionOne Core
 Here is a small snippet that can be added to your `~/.bash_profile` that provides aliases for linking the component library:
 
 ```

--- a/README.mdx
+++ b/README.mdx
@@ -31,3 +31,35 @@ Clone the repo and `cd` into the repo's directory.
 - [Developer Guide](getting-started/developer-guide)
 - [Implement Components](getting-started/implement-components)
 - [Document Components](getting-started/document-components)
+
+
+## Working locally with a consuming application
+In some cases we need to enhance the component library and receive quick feedback of the changes in a consuming applicaiton like VersionOne or Continuum.
+Here is a small snippet that can be added to your `~/.bash_profile` that provides aliases for linking the component library:
+
+```
+DEV_HOME="C:/development"
+CORE_DIR="$DEV_HOME/core"
+CL_DIR="$DEV_HOME/component-library"
+
+function link() {
+    cd "$CL_DIR/packages/components"
+    yarn link
+    cd "$CORE_DIR/VersionOne.Web"
+    yarn link "@versionone/components"
+    cd $CL_DIR
+    yarn build
+    cd $CORE_DIR
+    ./gulp watch
+}
+
+function buildLink() {
+    cd $CL_DIR
+    yarn build
+    cd $CORE_DIR
+    ./gulp watch
+}
+
+alias blink="buildLink"
+alias link="link"
+```

--- a/README.mdx
+++ b/README.mdx
@@ -36,7 +36,7 @@ Clone the repo and `cd` into the repo's directory.
 ## Linking 
 In some cases we need to enhance the component library and receive quick feedback of the changes in a consuming applicaiton like VersionOne or Continuum.
 
-### Working locally with a VersionOne Core
+### Working locally with VersionOne (Core)
 Here is a small snippet that can be added to your `~/.bash_profile` that provides aliases for linking the component library:
 
 ```


### PR DESCRIPTION
There seems to be insufficient written instructions on linking the component library to use local changes in a consuming application. I have included a script that can be added to your `~/.bash_profile` that demonstrates linking with VersionOne.