### PR TITLE
Fixes to Firefox Radios

### DIFF
--- a/packages/components/src/Checkbox/Checkbox.js
+++ b/packages/components/src/Checkbox/Checkbox.js
@@ -146,7 +146,7 @@ Checkbox.defaultProps = {
   checked: false,
   disabled: false,
   onClick: noop,
-  size: 24,
+  size: 16,
   tabIndex: '0',
   onFocus: noop,
   onBlur: noop,

--- a/packages/components/src/Radio/Radio.js
+++ b/packages/components/src/Radio/Radio.js
@@ -7,6 +7,7 @@ const InvisibleInput = createComponent(
   () => ({
     height: 0,
     width: 0,
+    opacity: 0,
     alignItems: 'center',
     position: 'relative',
     outline: 'none',
@@ -140,7 +141,7 @@ Radio.propTypes = {
 Radio.defaultProps = {
   disabled: false,
   onClick: noop,
-  size: 32,
+  size: 24,
   tabIndex: '0',
 };
 

--- a/packages/components/src/defaultTheme/index.js
+++ b/packages/components/src/defaultTheme/index.js
@@ -144,7 +144,7 @@ const internalTheme = {
       main: palette.forge,
     },
     default: {
-      main: 'rgb(99, 76, 71)',
+      main: palette.chrome50,
     },
     required: {
       main: palette.sunset,


### PR DESCRIPTION
Height/Width being 0 does not make browser radios invisiblein FIreFox, need Opacity 0
Color is wrong on Labels