### PR TITLE
Fixed - IconSwitch - different background color to indicate checked/unchecked

### DIFF
--- a/packages/components/src/Switch/IconSwitch.js
+++ b/packages/components/src/Switch/IconSwitch.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { noop } from 'underscore';
 import { createComponent, WithTheme } from '../StyleProvider';
-import { palette } from '../palette';
 
 const Root = createComponent(
   ({ size }) => ({
@@ -21,8 +20,10 @@ const Root = createComponent(
 const IconSwitchImpl = createComponent(
   ({ disabled, size, fill, theme }) => ({
     alignItems: 'center',
-    borderColor: 'transparent',
-    backgroundColor: theme.Button.text.background,
+    borderColor: fill ? theme.Button.icon.background : 'transparent',
+    backgroundColor: fill
+      ? theme.Button.icon.background
+      : theme.Button.text.background,
     color: theme.Button.standard.text,
     height: size,
     width: size,
@@ -147,7 +148,7 @@ IconSwitch.propTypes = {
    */
   checkedIcon: PropTypes.node.isRequired,
   /**
-   * If true the background is solid gunmetal to indicate checked
+   * If true the background is filled to indicate checked/unchecked
    */
   fill: PropTypes.bool,
   /**

--- a/packages/components/src/Switch/IconSwitch.mdx
+++ b/packages/components/src/Switch/IconSwitch.mdx
@@ -35,7 +35,8 @@ This Switch is used to toggle between two mutually exclusive options and is visu
           <IconSwitch
             checkedIcon={<CheckIcon color={palette.gunmetal} />}
             uncheckedIcon={<CloseIcon />}
-            checked />}
+            checked
+            fill />}
       />
     </SpacedGroup>
     <SpacedGroup xs={2} center>

--- a/packages/components/src/defaultTheme/index.js
+++ b/packages/components/src/defaultTheme/index.js
@@ -131,6 +131,7 @@ const internalTheme = {
     icon: {
       focusBorder: 'rgba(30,170,189,0.7)',
       focusBoxShadow: '0 0 7px 0 rgba(30,170,189,0.5)',
+      background: palette.chrome200,
     },
   },
   Drawer: {
@@ -549,6 +550,9 @@ const themeDark = {
     },
     disabled: {
       text: 'rgb(255, 255, 255, 0.5)',
+    },
+    icon: {
+      background: palette.chrome700,
     },
   },
   Drawer: {


### PR DESCRIPTION
Showing different background color using fill prop is existing functionality. Fixed where it has been removed.

Useful when same Icon is used for both checked/unchecked.

Currently fill prop is used in Saved Views (IncludeScopeToggleButton). This change is needed for S-59565 (Milestone Toggle in Roadmapping).